### PR TITLE
Docker file fix and upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,8 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Expose 3000
 EXPOSE 3000
 
+HEALTHCHECK --interval=30s --timeout=10s \
+    CMD curl http://localhost:3000/unoconv/health
+
 # Startup
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
+FROM golang:1.11 as api-builder
+WORKDIR /unoconv-api
+COPY . /unoconv-api
+RUN go build
+
+
 FROM ubuntu:xenial
 
-MAINTAINER Rene Kaufmann <kaufmann.r@gmail.com>
+LABEL maintainer="kaufmann.r@gmail.com"
 
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-ENV GO15VENDOREXPERIMENT 1
-
-ADD . /go/src/github.com/HeavyHorst/unoconv-api
+COPY --from=api-builder /unoconv-api/unoconv-api /opt/unoconv-api/unoconv-api
 
 #Install unoconv
 RUN \
@@ -16,14 +18,11 @@ RUN \
 		apt-get install -y \
 		        locales \
 			unoconv \
-			gcc \
-			supervisor \
-			golang-go && \
-		go install github.com/HeavyHorst/unoconv-api && \
-        apt-get remove -y golang-go gcc && \
+			supervisor && \
+        apt-get remove -y && \
 	    apt-get autoremove -y && \
         apt-get clean && \
-	    rm -rf /var/lib/apt/lists/
+			rm -rf /var/lib/apt/lists/
 
 # Set the locale
 RUN locale-gen de_DE.UTF-8  

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -8,7 +8,7 @@ autostart=true
 autorestart=true
 
 [program:unoconv-api]
-command=/go/bin/unoconv-api
+command=/opt/unoconv-api/unoconv-api
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
Closes #3 
- Fix Docker file to build using golang 1.11;
- Add multi-stage build (golang is no longer in the final image). total image size is 43mb less than before;
- Use Docker HealthCheck with the new `/unoconv/health`. With docker-swarm for example, the swarm can restart the container if it has any problem.